### PR TITLE
Fix group lookup failing on large GitLab instances

### DIFF
--- a/github2gitlab/main.py
+++ b/github2gitlab/main.py
@@ -96,7 +96,7 @@ class GitHub2GitLab(object):
 
         g = self.gitlab
         url = g['url'] + "/groups"
-        query = {'private_token': g['token'], 'all_available': 'true', 'per_page': 10000}
+        query = {'private_token': g['token'], 'all_available': 'true', 'per_page': 100, 'search': g['namespace'].split('/')[-1]}
         groups = requests.get(url, params=query).json()
         matches = list(filter(lambda group: group['full_path'] == g['namespace'].lower(), groups))
         if any(matches):


### PR DESCRIPTION
## Problem

The groups API query used `per_page=10000`, which GitLab silently caps at 100. On instances with more than 100 groups, the target namespace may not appear in results, causing `group_id` to stay `None` and project creation to fall back to the user's personal namespace, producing the error:

> You cannot create projects in your personal namespace.

## Fix

Add a `search=` parameter using the leaf component of the namespace (e.g. `myaccident` from `MyAccident`, or `findlaw-tech` from `findlaw/findlaw-tech`). This filters server-side so pagination is never an issue. The existing `full_path` comparison then disambiguates if multiple groups share the same leaf name.